### PR TITLE
Defer and delegate event listeners

### DIFF
--- a/src/trix-editor-element.ts
+++ b/src/trix-editor-element.ts
@@ -16,17 +16,6 @@ export interface TrixEditorInput {
 
   selectionEnd: number
 
-  addEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions
-  ): void
-  removeEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | EventListenerOptions
-  ): void
-
   focus(options?: FocusOptions): void
 
   setAttribute(name: string, value: string): void
@@ -38,22 +27,6 @@ export class TrixEditorElementAdapter implements TrixEditorInput {
 
   constructor(element: TrixEditorElement) {
     this.element = element
-  }
-
-  addEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions
-  ): void {
-    this.element.addEventListener(type, listener, options)
-  }
-
-  removeEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | EventListenerOptions
-  ): void {
-    this.element.removeEventListener(type, listener, options)
   }
 
   focus(options?: FocusOptions): void {
@@ -69,9 +42,9 @@ export class TrixEditorElementAdapter implements TrixEditorInput {
   }
 
   get selectionEnd(): number {
-    const selectionRange = this.element.editor.getSelectedRange()
+    const [, selectionEnd] = this.editor.getSelectedRange()
 
-    return selectionRange[1]
+    return selectionEnd
   }
 
   get value(): string {


### PR DESCRIPTION
Limit the amount of `<trix-editor>` element adapting necessary by
declaring event handlers on the `TrixMentionsElement` directly. For
event listeners that were previously attached to `this.input`, defer
checks that the bubbling events' targets are references to `this.input`
until bubble-time.

Similarly, when receiving a `fragment:` option in the
`trix-mentions-change` event's `provide` Promise, check whether or not
it [isConnected][]. During combobox activation, If it's already
connected to the document, remove its `[hidden]` attribute. If it's a
fragment that isn't yet connected, append it to the expander. During
deactivation, set `[hidden]` when the menu was already connected, or
remove it if it started out as a fragment.

[isConnected]: https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected