### PR TITLE
Resolve cursor offset issues

### DIFF
--- a/src/trix-editor-element.ts
+++ b/src/trix-editor-element.ts
@@ -4,8 +4,8 @@ export type TrixEditor = {
   deleteInDirection(direction: 'backward'): void
   insertAttachment(attachment: TrixAttachment): void
   getDocument(): TrixDocument
-  getSelectedRange(): [number, number]
-  setSelectedRange(range: [number, number]): void
+  getPosition(): number
+  setSelectedRange(range: number | [number] | [number, number]): void
 }
 export type TrixEditorElement = HTMLElement & {editor: TrixEditor}
 
@@ -42,9 +42,7 @@ export class TrixEditorElementAdapter implements TrixEditorInput {
   }
 
   get selectionEnd(): number {
-    const [, selectionEnd] = this.editor.getSelectedRange()
-
-    return selectionEnd
+    return this.editor.getPosition() + 1
   }
 
   get value(): string {

--- a/src/trix-mentions-element.ts
+++ b/src/trix-mentions-element.ts
@@ -145,7 +145,7 @@ class TrixMentionsExpander {
     if (!match) return
 
     const selectionStart = match.position - match.key.length
-    const selectionEnd = match.position + match.text.length + 1
+    const selectionEnd = match.position + match.text.length
 
     const detail = {item, key: match.key, value: null}
     const canceled = !this.expander.dispatchEvent(new CustomEvent('trix-mentions-value', {cancelable: true, detail}))
@@ -212,7 +212,7 @@ class TrixMentionsExpander {
 
   findMatch(): Match | void {
     const cursor = this.input.selectionEnd || 0
-    const text = this.input.value
+    const text = this.input.value.replace(/\n+$/, '')
     if (cursor <= this.lookBackIndex) {
       this.lookBackIndex = cursor - 1
     }

--- a/test/trix-mentions-element-test.js
+++ b/test/trix-mentions-element-test.js
@@ -299,8 +299,8 @@ describe('trix-mentions element', function () {
     it('toggles the visibility when activated and deactivated', async function () {
       const expander = document.querySelector('trix-mentions')
       const input = expander.querySelector('trix-editor')
-      const menu = document.querySelector('ul')
-      const item = document.querySelector('li')
+      const menu = expander.querySelector('ul')
+      const item = expander.querySelector('li')
 
       expander.addEventListener('trix-mentions-change', ({detail: {provide}}) => {
         provide(Promise.resolve({matched: true, fragment: menu}))
@@ -310,12 +310,16 @@ describe('trix-mentions element', function () {
       triggerInput(input, ':')
       await waitForAnimationFrame()
 
-      assert.equal(menu.hidden, false)
+      assert(menu.isConnected)
+      assert.deepEqual([menu], Array.from(expander.querySelectorAll('ul')))
+      assert.equal(false, menu.hidden)
 
       item.click()
       await waitForAnimationFrame()
 
-      assert.equal(menu.hidden, true)
+      assert(menu.isConnected)
+      assert.equal(expander, menu.parentElement)
+      assert.equal(true, menu.hidden)
     })
   })
 
@@ -347,12 +351,12 @@ function once(element, eventName) {
 
 function triggerInput(input, value, onlyAppend = false) {
   const editor = input.editor
-  const [, selectionEnd] = editor.getSelectedRange()
+  const selectionEnd = editor.getPosition()
   if (onlyAppend) {
-    editor.setSelectedRange([selectionEnd, selectionEnd])
+    editor.setSelectedRange(selectionEnd)
     editor.insertString(value)
   } else {
-    editor.setSelectedRange([0, 0])
+    editor.setSelectedRange([0, selectionEnd])
     editor.insertString(value)
   }
   return input.dispatchEvent(new InputEvent('input'))


### PR DESCRIPTION
When calling `Trix.Document.toString()`, the document will always
contain a newline character. The presence of this character combined
with the `TrixEditorElementAdapter.selectionEnd` property's
implementation meant that forward characters (inserted while typing left
to right) were omitted, and backward characters (queried while deleting
right to left) included the newline.

This commit resolves those issues by ignoring all trailing newline
characters from queries, and by changing the `selectionEnd`
implementation to advance the cursor an extra position forward.