### PR TITLE
Build-in support for Turbo Frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,35 @@ Often times, when `[role="option"]` elements encode the `Trix.Attachment`
 arguments into their `data-trix-attachment`-prefixed attributes,
 `trix-mentions-value` event listeners can be omitted entirely.
 
+## Built-in support for Turbo Frames
+
+All `<trix-mentions>` elements have built-in support for driving
+[`<turbo-frame>` elements][turbo-frame].
+
+First, render them with a `[name]` attribute to serve as the query parameter
+key, and a `[data-turbo-frame]` attribute that references a `<turbo-frame>`
+element with a matching `[id]` attribute:
+
+```html
+<trix-mentions key="@" name="query" data-turbo-frame="users">
+  <trix-editor></trix-editor>
+</trix-mentions>
+<turbo-frame id="users" role="listbox" hidden></turbo-frame>
+```
+
+Make sure to render the `<turbo-frame>` with the `[hidden]` attribute to start.
+
+Then, whenever a `trix-mentions-change` event is dispatched that bubbles without
+any calls to `CustomEvent.detail.provide`, the `<trix-mentions>` element will
+merge its current match's text into the into the `<turbo-frame>` element's
+`[src]` attribute, using the `[name]` attribute as its key. It'll wait for the
+[FrameElement.loaded][] promise to resolve before proceeding. Finally, it'll
+manage the `<turbo-frame>` element's `[hidden]` attribute and keep it
+synchronized with the visibility of the expanded list of options.
+
+[turbo-frame]: https://turbo.hotwired.dev/handbook/introduction#turbo-frames%3A-decompose-complex-pages
+[FrameElement.loaded]: https://turbo.hotwired.dev/reference/frames#properties
+
 ## Browser support
 
 Browsers without native [custom element support][support] require a [polyfill][].

--- a/examples/index.html
+++ b/examples/index.html
@@ -21,6 +21,7 @@
       }
     </style>
     <script src="https://unpkg.com/trix@1.3.1/dist/trix.js"></script>
+    <script src="https://unpkg.com/@hotwired/turbo@7.1.0/dist/turbo.es2017-umd.js"></script>
     <link href="https://unpkg.com/trix@1.3.1/dist/trix.css" media="screen" rel="stylesheet"/>
   </head>
   <body>
@@ -36,6 +37,13 @@
     <trix-mentions keys="#" multiword="#">
       <trix-editor class="trix-content" autofocus></trix-editor>
     </trix-mentions>
+
+    <h2>Turbo Frame integration</h2>
+    <p>Use <code>@</code> to trigger the expander</p>
+    <trix-mentions keys="@" name="query" data-turbo-frame="users">
+      <trix-editor class="trix-content" autofocus></trix-editor>
+    </trix-mentions>
+    <turbo-frame id="users" role="listbox" src="/examples/users.html" hidden></turbo-frame>
 
     <script type="text/javascript">
       const expanders = document.querySelectorAll('trix-mentions')
@@ -66,7 +74,7 @@
         })
       }
     </script>
-    <script type="module" src="https://unpkg.com/@thoughtbot/trix-mentions-element@latest/dist/bundle.js"></script>
-    <!-- <script src="../dist/bundle.js" type="module"></script> -->
+    <!-- <script type="module" src="https://unpkg.com/@thoughtbot/trix&#45;mentions&#45;element@latest/dist/bundle.js"></script> -->
+    <script src="../dist/bundle.js" type="module"></script>
   </body>
 </html>

--- a/examples/users.html
+++ b/examples/users.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Users</title>
+  </head>
+
+  <body>
+    <turbo-frame id="users" role="listbox">
+      <button type="button" role="option">Alice</button>
+      <button type="button" role="option">Bob</button>
+      <button type="button" role="option">Carol</button>
+      <button type="button" role="option">Dan</button>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/turbo.ts
+++ b/src/turbo.ts
@@ -1,0 +1,16 @@
+export type FrameElement = HTMLElement & {
+  loaded: Promise<void> | null
+}
+
+export function getFrameElementById(id: string | null): FrameElement | null {
+  return document.querySelector<FrameElement>(`turbo-frame#${id}:not([disabled])`)
+}
+
+export async function setSearchParam(element: FrameElement, name: string, value: string): Promise<void> {
+  const src = element.getAttribute('src') || ''
+  const url = new URL(src, element.baseURI)
+  url.searchParams.set(name, value)
+  element.setAttribute('src', url.toString())
+
+  return element.loaded || Promise.resolve()
+}

--- a/test/trix-mentions-element-test.js
+++ b/test/trix-mentions-element-test.js
@@ -323,6 +323,61 @@ describe('trix-mentions element', function () {
     })
   })
 
+  describe('driving a turbo-frame', function () {
+    it('writes its [name] and text to the turbo-frame[src]', async function () {
+      document.body.innerHTML = `
+        <trix-mentions keys=":" name="query" data-turbo-frame="menu">
+          <trix-editor></trix-editor>
+        </trix-mentions>
+        <turbo-frame id="menu" src="/path?c=d" role="listbox" hidden>
+          <button role="option">a</button>
+        </turbo-frame>
+      `
+      const input = document.querySelector('trix-editor')
+      const frame = document.querySelector('turbo-frame')
+      triggerInput(input, ':a')
+      await waitForAnimationFrame()
+
+      assert.equal(
+        new URL(frame.getAttribute('src'), document.baseURI).toString(),
+        new URL('/path?c=d&query=a', document.baseURI).toString()
+      )
+      assert.equal(frame.hidden, false)
+    })
+
+    it('writes its [name] and text to the turbo-frame[src]', async function () {
+      document.body.innerHTML = `
+        <trix-mentions keys=":" name="query" data-turbo-frame="menu">
+          <trix-editor></trix-editor>
+        </trix-mentions>
+        <turbo-frame id="menu" src="/path" role="listbox" hidden></turbo-frame>
+      `
+      const input = document.querySelector('trix-editor')
+      const frame = document.querySelector('turbo-frame')
+      triggerInput(input, ':a')
+      await waitForAnimationFrame()
+
+      assert.equal(frame.hidden, true)
+    })
+
+    it('does not drive a turbo-frame[disabled]', async function () {
+      document.body.innerHTML = `
+        <trix-mentions keys=":" name="query" data-turbo-frame="menu">
+          <trix-editor></trix-editor>
+        </trix-mentions>
+        <turbo-frame id="menu" src="/path" role="listbox" hidden disabled></turbo-frame>
+      `
+      const input = document.querySelector('trix-editor')
+      const frame = document.querySelector('turbo-frame')
+      triggerInput(input, ':a')
+      await waitForAnimationFrame()
+
+      assert.equal(frame.getAttribute('src'), '/path')
+      assert(frame.hasAttribute('disabled'))
+      assert(frame.hidden)
+    })
+  })
+
   describe('use inside a ShadowDOM', function () {
     before(function () {
       customElements.define('wrapper-component', WrapperComponent)


### PR DESCRIPTION
All `<trix-mentions>` elements have built-in support for driving
[`<turbo-frame>` elements][turbo-frame].

First, render them with a `[name]` attribute to serve as the query
parameter key, and a `[data-turbo-frame]` attribute that references a
`<turbo-frame>` element with a matching `[id]` attribute:

```html
<trix-mentions key="@" name="query" data-turbo-frame="users">
  <trix-editor></trix-editor>
</trix-mentions>
<turbo-frame id="users" role="listbox" hidden></turbo-frame>
```

Make sure to render the `<turbo-frame>` with the `[hidden]` attribute to
start.

Then, whenever a `trix-mentions-change` event is dispatched that bubbles
without any calls to `CustomEvent.detail.provide`, the `<trix-mentions>`
element will merge its current match's text into the into the
`<turbo-frame>` element's `[src]` attribute, using the `[name]`
attribute as its key. It'll wait for the [FrameElement.loaded][] promise
to resolve before proceeding. Finally, it'll manage the `<turbo-frame>`
element's `[hidden]` attribute and keep it synchronized with the
visibility of the expanded list of options.

[turbo-frame]: https://turbo.hotwired.dev/handbook/introduction#turbo-frames%3A-decompose-complex-pages
[FrameElement.loaded]: https://turbo.hotwired.dev/reference/frames#properties