### PR TITLE
Bugfix: Read `[data-trix-attachment]` from commit

### DIFF
--- a/src/trix-editor-element.ts
+++ b/src/trix-editor-element.ts
@@ -61,10 +61,11 @@ declare global {
   }
 }
 
-function getJSONAttribute(element: HTMLElement, key: string): any {
+function getJSONAttribute(element: HTMLElement, key: string): Record<string, unknown> {
   try {
     const value = element.getAttribute(key)
-    JSON.parse(value || '{}')
+
+    return JSON.parse(value || '{}')
   } catch {
     return {}
   }
@@ -80,7 +81,7 @@ function extractDataAttribute(dataset: DOMStringMap, key: string, prefix: string
   return [name, value]
 }
 
-export function buildTrixAttachment(elementOrOptions: HTMLElement | Record<string, any>): TrixAttachment | null {
+export function buildTrixAttachment(elementOrOptions: HTMLElement | Record<string, unknown>): TrixAttachment | null {
   const attribute = 'data-trix-attachment'
   const prefix = 'trixAttachment'
 
@@ -89,7 +90,7 @@ export function buildTrixAttachment(elementOrOptions: HTMLElement | Record<strin
 
     const defaults = {content: element.innerHTML}
     const options = getJSONAttribute(element, attribute)
-    const overrides: Record<string, any> = {}
+    const overrides: Record<string, unknown> = {}
 
     const {dataset} = element
     for (const key in dataset) {

--- a/test/trix-mentions-element-test.js
+++ b/test/trix-mentions-element-test.js
@@ -126,7 +126,7 @@ describe('trix-mentions element', function () {
       })
 
       it('forwards the [data-trix-attachment] attribute to the Trix.Attachment instance without a trix-mentions-value listener', async function () {
-        const attachmentOptions = {content: 'content override', contentType: 'ignored'}
+        const attachmentOptions = {contentType: 'ignored', sgid: 'a-hash'}
         const expander = document.querySelector('trix-mentions')
         const input = expander.querySelector('trix-editor')
         const menu = document.querySelector('ul')
@@ -148,7 +148,8 @@ describe('trix-mentions element', function () {
         await waitForAnimationFrame()
 
         const figure = input.querySelector('figure')
-        const {content, contentType} = JSON.parse(figure.getAttribute('data-trix-attachment'))
+        const {content, contentType, sgid} = JSON.parse(figure.getAttribute('data-trix-attachment'))
+        assert.equal(sgid, 'a-hash')
         assert.equal(item.textContent, content)
         assert.equal('mime', contentType)
         assert.equal('mime', figure.getAttribute('data-trix-content-type'))


### PR DESCRIPTION
The `getJSONAttribute` helper's return type was `any`, which includes
`undefined`. Unfortunately, that return type obscured the fact that the
initial implementation lacked a `return` statement in the `try { ... }`
block, resulting in an `undefined` value when it should have otherwise
been the contents of a committing element's `[data-trix-attachment]`
attribute.

To resolve the underlying issue, replace the `any` return type with a
`Record<string, unknown>`, which guarantees that _something_ is
returned.