### PR TITLE
Document Trix-powered Action Text mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2022-08-07
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -153,6 +153,186 @@ synchronized with the visibility of the expanded list of options.
 [turbo-frame]: https://turbo.hotwired.dev/handbook/introduction#turbo-frames%3A-decompose-complex-pages
 [FrameElement.loaded]: https://turbo.hotwired.dev/reference/frames#properties
 
+## Trix-powered Action Text mentions
+
+Inspired by [Implementing rich-text mentions with Action Text][] by George
+Claghorn
+
+The `<trix-mentions>` element integrates with Action Text attachments to embed
+server-generated HTML renderings of Active Record instances.
+
+Start with a `User` model:
+
+```ruby
+class User < ApplicationRecord
+  scope :where_username_like, ->(text) {
+    if text.present?
+      where("username LIKE ?", text + "%")
+    else
+      none
+    end
+  }
+end
+```
+
+Include the [ActionText::Attachable][] module into the class:
+
+```diff
+ class User < ApplicationRecord
++  include ActionText::Attachable
++
+   scope :where_username_like, ->(text) {
+     if text.present?
+       where("username LIKE ?", text + "%")
+     else
+       none
+     end
+   }
+ end
+```
+
+Action Text will generate the HTML for an attached `User` record by rendering
+the partial name it returns from its
+`User#to_trix_content_attachment_partial_path` method. By default, that method
+will return `users/user`.
+
+If you'd like to render a different partial, override it to return a different
+path:
+
+```diff
+ class User < ApplicationRecord
+   include ActionText::Attachable
+
+   scope :where_username_like, ->(text) {
+     if text.present?
+       where("username LIKE ?", text + "%")
+     else
+       none
+     end
+   }
++
++  def to_trix_content_attachment_partial_path
++    "users/trix_content_attachment"
++  end
+ end
+```
+
+Then, declare the partial's template:
+
+```erb
+<%# app/views/users/_trix_content_attachment.html.erb %>
+<span>@<%= user.username %></span>
+```
+
+The record instance will be available under a key that matches its class name.
+In this case, `user`:
+
+Next, render the `<trix-mentions>`. In this example, we'll nest a
+`<trix-editor>` element to serve as its input, and a `<turbo-frame>` element to
+serve as its listbox:
+
+```erb
+<trix-mentions key="@" name="query" data-turbo-frame="users">
+  <trix-editor></trix-editor>
+  <turbo-frame id="users" role="listbox" hidden>
+  </turbo-frame>
+<trix-mentions>
+```
+
+Within the `<turbo-frame>` element, render a list of `[role="option"]` elements
+that match the value of `params[:query]`:
+
+```diff
+ <trix-mentions key="@" name="query" data-turbo-frame="users">
+   <trix-editor></trix-editor>
+   <turbo-frame id="users" role="listbox" hidden>
++    <% User.where_username_like(params[:query]).each do |user| %>
++      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1">
++        <%= render user.to_trix_content_attachment_partial_path, user: user %>
++     </button>
++    <% end %>
+   </turbo-frame>
+ <trix-mentions>
+```
+
+Then, encode the [`User#attachable_sgid`][attachable_sgid] into the element's
+`[data-trix-attachment-sgid]` attribute:
+
+```diff
+ <trix-mentions key="@" name="query" data-turbo-frame="users">
+   <trix-editor></trix-editor>
+   <turbo-frame id="users" role="listbox" hidden>
+     <% User.where_username_like(params[:query]).each do |user| %>
+-      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1">
++      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1"
++              data-trix-attachment-sgid="<%= user.attachable_sgid %>">
+         <%= render user.to_trix_content_attachment_partial_path, user: user %>
+      </button>
+     <% end %>
+   </turbo-frame>
+ <trix-mentions>
+```
+
+If the `Trix.Attachment` instance requires more attributes, you can encode their
+values under kebab-case key names with a `data-trix-attachment-` prefix, or as a
+single JSON-encoded object under the `[data-trix-attachment]` key:
+
+```diff
+ <trix-mentions key="@" name="query" data-turbo-frame="users">
+   <trix-editor></trix-editor>
+   <turbo-frame id="users" role="listbox" hidden>
+     <% User.where_username_like(params[:query]).each do |user| %>
+-      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1">
++      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1"
++              data-trix-attachment="<%= json_escape { sgid: user.attachable_sgid, content_type: "..." }.to_json %>">
+         <%= render user.to_trix_content_attachment_partial_path, user: user %>
+      </button>
+     <% end %>
+   </turbo-frame>
+ <trix-mentions>
+```
+
+Then, declare a partial template for Action Text to render when it encounters
+attached `User` instances. By default, Action Text will attempt to render
+`users/user`, but that partial path can be overridden by declaring
+`User#to_attachable_partial_path`:
+
+```diff
+ class User < ApplicationRecord
+   include ActionText::Attachable
+
+   scope :where_username_like, ->(text) {
+     if text.present?
+       where("username LIKE ?", text + "%")
+     else
+       none
+     end
+   }
+
+   def to_trix_content_attachment_partial_path
+     "users/trix_content_attachment"
+   end
+
++  def to_atachable_partial_path
++    "users/attachable"
++  end
+ end
+```
+
+Finally, declare the template to render an attached `User`:
+
+```erb
+<%# app/views/users/_attachable.html.erb %>
+
+<%= link_to user do %>
+  <%= render user.to_trix_content_attachment_partial_path, user: user %>
+<% end %>
+```
+
+[ActionText::Attachable]: https://edgeapi.rubyonrails.org/classes/ActionText/Attachable.html
+[Implementing rich-text mentions with Action Text]: https://gist.github.com/georgeclaghorn/c83b31a7e378fb07fba0c3d25835e5ba
+[attachable_sgid]: https://edgeapi.rubyonrails.org/classes/ActionText/Attachable.html#method-i-attachable_sgid
+
 ## Browser support
 
 Browsers without native [custom element support][support] require a [polyfill][].

--- a/examples/users.html
+++ b/examples/users.html
@@ -7,10 +7,10 @@
 
   <body>
     <turbo-frame id="users" role="listbox">
-      <button type="button" role="option">Alice</button>
-      <button type="button" role="option">Bob</button>
-      <button type="button" role="option">Carol</button>
-      <button type="button" role="option">Dan</button>
+      <button id="users-alice" type="button" role="option" tabindex="-1">Alice</button>
+      <button id="users-bob" type="button" role="option" tabindex="-1">Bob</button>
+      <button id="users-carol" type="button" role="option" tabindex="-1">Carol</button>
+      <button id="users-dan" type="button" role="option" tabindex="-1">Dan</button>
     </turbo-frame>
   </body>
 </html>


### PR DESCRIPTION
Inspired by [Implementing rich-text mentions with Action Text][] by
George Claghorn

The `<trix-mentions>` element integrates with Action Text attachments to
embed server-generated HTML renderings of Active Record instances.

Start with a `User` model:

```ruby
class User < ApplicationRecord
  scope :where_username_like, ->(text) {
    if text.present?
      where("username LIKE ?", text + "%")
    else
      none
    end
  }
end
```

Include the [ActionText::Attachable][] module into the class:

```diff
 class User < ApplicationRecord
+  include ActionText::Attachable
+
   scope :where_username_like, ->(text) {
     if text.present?
       where("username LIKE ?", text + "%")
     else
       none
     end
   }
 end
```

Action Text will generate the HTML for an attached `User` record by
rendering the partial name it returns from its
`User#to_trix_content_attachment_partial_path` method. By default, that
method will return `users/user`.

If you'd like to render a different partial, override it to return a
different path:

```diff
 class User < ApplicationRecord
   include ActionText::Attachable

   scope :where_username_like, ->(text) {
     if text.present?
       where("username LIKE ?", text + "%")
     else
       none
     end
   }
+
+  def to_trix_content_attachment_partial_path
+    "users/trix_content_attachment"
+  end
 end
```

Then, declare the partial's template:

```erb
<%# app/views/users/_trix_content_attachment.html.erb %>
<span>@<%= user.username %></span>
```

The record instance will be available under a key that matches its class
name. In this case, `user`:

Next, render the `<trix-mentions>`. In this example, we'll nest a
`<trix-editor>` element to serve as its input, and a `<turbo-frame>`
element to serve as its listbox:

```erb
<trix-mentions key="@" name="query" data-turbo-frame="users">
  <trix-editor></trix-editor>
  <turbo-frame id="users" role="listbox" hidden>
  </turbo-frame>
<trix-mentions>
```

Within the `<turbo-frame>` element, render a list of `[role="option"]`
elements that match the value of `params[:query]`:

```diff
 <trix-mentions key="@" name="query" data-turbo-frame="users">
   <trix-editor></trix-editor>
   <turbo-frame id="users" role="listbox" hidden>
+    <% User.where_username_like(params[:query]).each do |user| %>
+      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1">
+        <%= render user.to_trix_content_attachment_partial_path, user: user %>
+     </button>
+    <% end %>
   </turbo-frame>
 <trix-mentions>
```

Then, encode the [`User#attachable_sgid`][attachable_sgid] into the
element's `[data-trix-attachment-sgid]` attribute:

```diff
 <trix-mentions key="@" name="query" data-turbo-frame="users">
   <trix-editor></trix-editor>
   <turbo-frame id="users" role="listbox" hidden>
     <% User.where_username_like(params[:query]).each do |user| %>
-      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1">
+      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1"
+              data-trix-attachment-sgid="<%= user.attachable_sgid %>">
         <%= render user.to_trix_content_attachment_partial_path, user: user %>
      </button>
     <% end %>
   </turbo-frame>
 <trix-mentions>
```

If the `Trix.Attachment` instance requires more attributes, you can
encode their values under kebab-case key names with a
`data-trix-attachment-` prefix, or as a single JSON-encoded object under
the `[data-trix-attachment]` key:

```diff
 <trix-mentions key="@" name="query" data-turbo-frame="users">
   <trix-editor></trix-editor>
   <turbo-frame id="users" role="listbox" hidden>
     <% User.where_username_like(params[:query]).each do |user| %>
-      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1">
+      <button id="<%= dom_id(user, :mention) %>" type="button" role="option" tabindex="-1"
+              data-trix-attachment="<%= json_escape { sgid: user.attachable_sgid, content_type: "..." }.to_json %>">
         <%= render user.to_trix_content_attachment_partial_path, user: user %>
      </button>
     <% end %>
   </turbo-frame>
 <trix-mentions>
```

Then, declare a partial template for Action Text to render when it
encounters attached `User` instances. By default, Action Text will
attempt to render `users/user`, but that partial path can be overridden
by declaring `User#to_attachable_partial_path`:

```diff
 class User < ApplicationRecord
   include ActionText::Attachable

   scope :where_username_like, ->(text) {
     if text.present?
       where("username LIKE ?", text + "%")
     else
       none
     end
   }

   def to_trix_content_attachment_partial_path
     "users/trix_content_attachment"
   end

+  def to_atachable_partial_path
+    "users/attachable"
+  end
 end
```

Finally, declare the template to render an attached `User`:

```erb
<%# app/views/users/_attachable.html.erb %>

<%= link_to user do %>
  <%= render user.to_trix_content_attachment_partial_path, user: user %>
<% end %>
```

[ActionText::Attachable]: https://edgeapi.rubyonrails.org/classes/ActionText/Attachable.html
[Implementing rich-text mentions with Action Text]: https://gist.github.com/georgeclaghorn/c83b31a7e378fb07fba0c3d25835e5ba
[attachable_sgid]: https://edgeapi.rubyonrails.org/classes/ActionText/Attachable.html#method-i-attachable_sgid