### PR TITLE
Add support for `trix-mentions[src]` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for reading the URL directly from `trix-mentions[src]`, then
+  falling back to `turbo-frame[src]`.
+
 ## [0.1.0] - 2022-08-07
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ With a script tag:
 - `keys` is a space separated list of menu activation keys
 - `multiword` defines whether the expansion should use several words or not
   - you can provide a space separated list of activation keys that should support multi-word matching
+- `name` is the name of the key used when merging a match's text into a URL
+- `src` the path or URL to retrieve options from
+- `data-turbo-frame` used to identify which [`<turbo-frame>`][turbo-frame] element to
+  navigate when the menu of options is active
 
 ## Events
 
@@ -53,6 +57,17 @@ With a script tag:
 - `text`: The matched text; for example: `cat`, for `@cat`.
   - If the `key` is specified in the `multiword` attribute then the matched text can contain multiple words; for example `cat and dog` for `@cat and dog`.
 - `provide`: A function to be called when you have the menu results. Takes a `Promise` with `{matched: boolean, fragment: HTMLElement}` where `matched` tells the element whether a suggestion is available, and `fragment` is the menu content to be displayed on the page.
+
+> **Warning**
+>
+> Event listener callbacks are synchronous and will not block to wait for
+> `Promise` resolution. If your `provide` callback is asynchronous, make sure
+> to chain additional `Promise` instances with [Promise.then][], or make sure to
+> nest any [`async` or `await`][async] keywords _within_ the callback function
+> passed to `detail.provide`.
+
+[Promise.then]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+[async]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
 
 ```js
 const expander = document.querySelector('trix-mentions')
@@ -144,11 +159,15 @@ Make sure to render the `<turbo-frame>` with the `[hidden]` attribute to start.
 
 Then, whenever a `trix-mentions-change` event is dispatched that bubbles without
 any calls to `CustomEvent.detail.provide`, the `<trix-mentions>` element will
-merge its current match's text into the into the `<turbo-frame>` element's
-`[src]` attribute, using the `[name]` attribute as its key. It'll wait for the
-[FrameElement.loaded][] promise to resolve before proceeding. Finally, it'll
-manage the `<turbo-frame>` element's `[hidden]` attribute and keep it
-synchronized with the visibility of the expanded list of options.
+merge its current match's text into its `[src]` attribute (using the `[name]`
+attribute as its key) then write that value to the `<turbo-frame>` element's
+`[src]` attribute. It'll wait for the [FrameElement.loaded][] promise to resolve
+before proceeding. When the `<trix-mentions>` element's `[src]` attribute is
+missing, it'll merge the name-value pair directly into the `<turbo-frame>`
+element's `[src]` attribute's search parameters.
+
+Finally, it'll manage the `<turbo-frame>` element's `[hidden]` attribute and
+keep it synchronized with the visibility of the expanded list of options.
 
 [turbo-frame]: https://turbo.hotwired.dev/handbook/introduction#turbo-frames%3A-decompose-complex-pages
 [FrameElement.loaded]: https://turbo.hotwired.dev/reference/frames#properties

--- a/examples/index.html
+++ b/examples/index.html
@@ -40,10 +40,10 @@
 
     <h2>Turbo Frame integration</h2>
     <p>Use <code>@</code> to trigger the expander</p>
-    <trix-mentions keys="@" name="query" data-turbo-frame="users">
+    <trix-mentions keys="@" name="query" src="/examples/users.html" data-turbo-frame="users">
       <trix-editor class="trix-content" autofocus></trix-editor>
     </trix-mentions>
-    <turbo-frame id="users" role="listbox" src="/examples/users.html" hidden></turbo-frame>
+    <turbo-frame id="users" role="listbox" hidden></turbo-frame>
 
     <script type="text/javascript">
       const expanders = document.querySelectorAll('trix-mentions')

--- a/src/trix-mentions-element.ts
+++ b/src/trix-mentions-element.ts
@@ -267,7 +267,11 @@ class TrixMentionsExpander {
     const frame = getFrameElementById(this.expander.getAttribute('data-turbo-frame'))
 
     if (name && frame) {
-      await setSearchParam(frame, name, match.text)
+      const src = this.expander.src || frame.getAttribute('src') || ''
+
+      const url = await setSearchParam(frame, src, name, match.text)
+
+      this.expander.src = url.toString()
 
       if (frame.childElementCount > 0) {
         return frame
@@ -287,15 +291,27 @@ export default class TrixMentionsElement extends HTMLElement {
     return keys.map(key => ({key, multiWord: globalMultiWord || multiWord.includes(key)}))
   }
 
+  get src(): string | null {
+    return this.getAttribute('src')
+  }
+
+  set src(value: string | null) {
+    if (value === null || typeof value === 'undefined') {
+      this.removeAttribute('src')
+    } else {
+      this.setAttribute('src', value)
+    }
+  }
+
   get name(): string | null {
     return this.getAttribute('name')
   }
 
   set name(value: string | null) {
-    if (typeof value === 'string') {
-      this.setAttribute('name', value)
-    } else {
+    if (value === null || typeof value === 'undefined') {
       this.removeAttribute('name')
+    } else {
+      this.setAttribute('name', value)
     }
   }
 

--- a/src/turbo.ts
+++ b/src/turbo.ts
@@ -6,11 +6,12 @@ export function getFrameElementById(id: string | null): FrameElement | null {
   return document.querySelector<FrameElement>(`turbo-frame#${id}:not([disabled])`)
 }
 
-export async function setSearchParam(element: FrameElement, name: string, value: string): Promise<void> {
-  const src = element.getAttribute('src') || ''
+export async function setSearchParam(element: FrameElement, src: string, name: string, value: string): Promise<URL> {
   const url = new URL(src, element.baseURI)
   url.searchParams.set(name, value)
   element.setAttribute('src', url.toString())
 
-  return element.loaded || Promise.resolve()
+  await (element.loaded || Promise.resolve())
+
+  return url
 }

--- a/test/trix-mentions-element-test.js
+++ b/test/trix-mentions-element-test.js
@@ -325,25 +325,22 @@ describe('trix-mentions element', function () {
   })
 
   describe('driving a turbo-frame', function () {
-    it('writes its [name] and text to the turbo-frame[src]', async function () {
+    it('merges its [name] and text into its [src] attribute, then writes it to the turbo-frame[src]', async function () {
       document.body.innerHTML = `
-        <trix-mentions keys=":" name="query" data-turbo-frame="menu">
+        <trix-mentions keys=":" name="query" src="/path" data-turbo-frame="menu">
           <trix-editor></trix-editor>
         </trix-mentions>
-        <turbo-frame id="menu" src="/path?c=d" role="listbox" hidden>
-          <button role="option">a</button>
-        </turbo-frame>
+        <turbo-frame id="menu" role="listbox" hidden></turbo-frame>
       `
+      const expander = document.querySelector('trix-mentions')
       const input = document.querySelector('trix-editor')
       const frame = document.querySelector('turbo-frame')
       triggerInput(input, ':a')
       await waitForAnimationFrame()
 
-      assert.equal(
-        new URL(frame.getAttribute('src'), document.baseURI).toString(),
-        new URL('/path?c=d&query=a', document.baseURI).toString()
-      )
-      assert.equal(frame.hidden, false)
+      const url = expandURL('/path?query=a')
+      assert.equal(expandURL(frame.getAttribute('src')), url)
+      assert.equal(expandURL(expander.getAttribute('src')), url)
     })
 
     it('writes its [name] and text to the turbo-frame[src]', async function () {
@@ -351,14 +348,17 @@ describe('trix-mentions element', function () {
         <trix-mentions keys=":" name="query" data-turbo-frame="menu">
           <trix-editor></trix-editor>
         </trix-mentions>
-        <turbo-frame id="menu" src="/path" role="listbox" hidden></turbo-frame>
+        <turbo-frame id="menu" src="/path?c=d" role="listbox" hidden></turbo-frame>
       `
+      const expander = document.querySelector('trix-mentions')
       const input = document.querySelector('trix-editor')
       const frame = document.querySelector('turbo-frame')
       triggerInput(input, ':a')
       await waitForAnimationFrame()
 
-      assert.equal(frame.hidden, true)
+      const url = expandURL('/path?c=d&query=a')
+      assert.equal(expandURL(frame.getAttribute('src')), url)
+      assert.equal(expandURL(expander.getAttribute('src')), url)
     })
 
     it('does not drive a turbo-frame[disabled]', async function () {
@@ -422,4 +422,14 @@ async function waitForAnimationFrame() {
   return new Promise(resolve => {
     window.requestAnimationFrame(resolve)
   })
+}
+
+function expandURL(pathnameOrURL) {
+  if (pathnameOrURL === null || typeof pathnameOrURL === 'undefined') {
+    return null
+  } else {
+    const url = new URL(pathnameOrURL, document.baseURI)
+
+    return url.toString()
+  }
 }


### PR DESCRIPTION
First, attempt to read the URL directly from the `trix-mentions[src]`
value. When that is absent, fall back to using the target
`turbo-frame[src]`.