### PR TITLE
Do not update `trix-mentions[src]` when matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Change: only write `[name]` and match text to `turbo-frame[src]`, don't alter
+  `trix-mentions[src]`
+
 ## [0.1.0] - 2022-08-07
 
 - Add support for reading the URL directly from `trix-mentions[src]`, then

--- a/src/trix-mentions-element.ts
+++ b/src/trix-mentions-element.ts
@@ -267,11 +267,7 @@ class TrixMentionsExpander {
     const frame = getFrameElementById(this.expander.getAttribute('data-turbo-frame'))
 
     if (name && frame) {
-      const src = this.expander.src || frame.getAttribute('src') || ''
-
-      const url = await setSearchParam(frame, src, name, match.text)
-
-      this.expander.src = url.toString()
+      await setSearchParam(frame, this.expander.src, name, match.text)
 
       if (frame.childElementCount > 0) {
         return frame

--- a/src/turbo.ts
+++ b/src/turbo.ts
@@ -6,12 +6,10 @@ export function getFrameElementById(id: string | null): FrameElement | null {
   return document.querySelector<FrameElement>(`turbo-frame#${id}:not([disabled])`)
 }
 
-export async function setSearchParam(element: FrameElement, src: string, name: string, value: string): Promise<URL> {
-  const url = new URL(src, element.baseURI)
+export function setSearchParam(element: FrameElement, src: string | null, name: string, value: string): Promise<void> {
+  const url = new URL(src || element.getAttribute('src') || '', element.baseURI)
   url.searchParams.set(name, value)
   element.setAttribute('src', url.toString())
 
-  await (element.loaded || Promise.resolve())
-
-  return url
+  return element.loaded || Promise.resolve()
 }

--- a/test/trix-mentions-element-test.js
+++ b/test/trix-mentions-element-test.js
@@ -338,9 +338,8 @@ describe('trix-mentions element', function () {
       triggerInput(input, ':a')
       await waitForAnimationFrame()
 
-      const url = expandURL('/path?query=a')
-      assert.equal(expandURL(frame.getAttribute('src')), url)
-      assert.equal(expandURL(expander.getAttribute('src')), url)
+      assert.equal(expandURL(frame.getAttribute('src')), expandURL('/path?query=a'))
+      assert.equal(expandURL(expander.getAttribute('src')), expandURL('/path'))
     })
 
     it('writes its [name] and text to the turbo-frame[src]', async function () {
@@ -356,9 +355,8 @@ describe('trix-mentions element', function () {
       triggerInput(input, ':a')
       await waitForAnimationFrame()
 
-      const url = expandURL('/path?c=d&query=a')
-      assert.equal(expandURL(frame.getAttribute('src')), url)
-      assert.equal(expandURL(expander.getAttribute('src')), url)
+      assert.equal(expandURL(frame.getAttribute('src')), expandURL('/path?c=d&query=a'))
+      assert.equal(expandURL(expander.getAttribute('src')), null)
     })
 
     it('does not drive a turbo-frame[disabled]', async function () {


### PR DESCRIPTION
Only write `[name]` and match text to `turbo-frame[src]`, don't alter
`trix-mentions[src]`. Driving the `<turbo-frame>` should be idempotent
with regard to the `<trix-mentions>`, and should have no side effects.